### PR TITLE
Add windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall": "../git-guppy/scripts/install.js pre-commit"
+    "postinstall": "guppy pre-commit"
   },
   "dependencies": {
-    "git-guppy": "git+https://github.com/marcellodesales/git-guppy.git#1.0.0",
+    "guppy-cli": "^0.2.4",
     "named-regexp": "^0.1.1"
   }
 }


### PR DESCRIPTION
I can't seem to find the scripts folder in the package it's referring to, but the guppy command seems to work well.
